### PR TITLE
Fix deprecated PHP 7.4 Function ReflectionType::__toString()

### DIFF
--- a/src/Tsufeki/KayoJsonMapper/MetadataProvider/ReflectionCallableMetadataProvider.php
+++ b/src/Tsufeki/KayoJsonMapper/MetadataProvider/ReflectionCallableMetadataProvider.php
@@ -100,7 +100,7 @@ class ReflectionCallableMetadataProvider implements CallableMetadataProvider
     /**
      * @return Type|null
      */
-    private function resolveReflectionType(\ReflectionType $reflectionType = null)
+    private function resolveReflectionType(\ReflectionNamedType $reflectionType = null)
     {
         if ($reflectionType === null) {
             return null;

--- a/src/Tsufeki/KayoJsonMapper/MetadataProvider/ReflectionCallableMetadataProvider.php
+++ b/src/Tsufeki/KayoJsonMapper/MetadataProvider/ReflectionCallableMetadataProvider.php
@@ -108,7 +108,7 @@ class ReflectionCallableMetadataProvider implements CallableMetadataProvider
 
         $typeResolver = new TypeResolver();
         $nullable = $reflectionType->allowsNull() ? '|null' : '';
-        $type = $typeResolver->resolve((string)$reflectionType . $nullable);
+        $type = $typeResolver->resolve($reflectionType->getName() . $nullable);
 
         return $type;
     }


### PR DESCRIPTION
Fix is what's suggested on https://www.php.net/manual/en/reflectionparameter.gettype.php

The change is compatible from PHP >= 7.1.0 which is a requirement in composer.json